### PR TITLE
Keeping unsaved changes when DTA editor is closed for asset, also added editor close save check dialog to have parity with UE assets

### DIFF
--- a/Source/SGDynamicTextAssetsEditor/Private/Browser/SSGDynamicTextAssetTileView.cpp
+++ b/Source/SGDynamicTextAssetsEditor/Private/Browser/SSGDynamicTextAssetTileView.cpp
@@ -16,11 +16,13 @@
 #include "HAL/PlatformApplicationMisc.h"
 #include "Misc/MessageDialog.h"
 #include "ReferenceViewer/SGDynamicTextAssetReferenceSubsystem.h"
+#include "Widgets/SOverlay.h"
 #include "Widgets/Views/STableRow.h"
 #include "Widgets/Images/SImage.h"
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/Layout/SBox.h"
 #include "Widgets/Layout/SSpacer.h"
+#include "Styling/AppStyle.h"
 
 FText FSGDTAAssetListItem::GetDisplayName() const
 {
@@ -254,8 +256,27 @@ TSharedRef<ITableRow> SSGDynamicTextAssetTileView::GenerateRow(TSharedPtr<FSGDTA
             .VAlign(VAlign_Center)
             .Padding(2.0f, 0.0f)
             [
-                SNew(SSGDynamicTextAssetIcon)
-                .Serializer(weakSerializer)
+                SNew(SOverlay)
+
+                + SOverlay::Slot()
+                [
+                    SNew(SSGDynamicTextAssetIcon)
+                    .Serializer(weakSerializer)
+                ]
+
+                + SOverlay::Slot()
+                .HAlign(HAlign_Left)
+                .VAlign(VAlign_Top)
+                [
+                    SNew(SImage)
+                    .Image(FAppStyle::GetBrush("ContentBrowser.ContentDirty"))
+                    .Visibility_Lambda([Item]()
+                    {
+                        return FSGDynamicTextAssetEditorToolkit::HasOpenEditorWithUnsavedChanges(Item->FilePath)
+                            ? EVisibility::HitTestInvisible
+                            : EVisibility::Collapsed;
+                    })
+                ]
             ]
 
             // Name and class

--- a/Source/SGDynamicTextAssetsEditor/Private/Editor/SGDynamicTextAssetEditorToolkit.cpp
+++ b/Source/SGDynamicTextAssetsEditor/Private/Editor/SGDynamicTextAssetEditorToolkit.cpp
@@ -10,6 +10,8 @@
 #include "Editor.h"
 #include "Editor/SGDynamicTextAssetBundleRowExtension.h"
 #include "Editor/SGDynamicTextAssetEditorCommands.h"
+#include "Editor/SSGDynamicTextAssetSaveDialog.h"
+#include "Interfaces/IMainFrameModule.h"
 #include "Editor/SSGDynamicTextAssetRawView.h"
 #include "Framework/Docking/TabManager.h"
 #include "Framework/MultiBox/MultiBoxBuilder.h"
@@ -30,6 +32,7 @@
 #include "Utilities/SGDynamicTextAssetSourceControl.h"
 #include "Utilities/SGDynamicTextAssetEditorStatics.h"
 #include "Widgets/Docking/SDockTab.h"
+#include "Widgets/SWindow.h"
 #include "Widgets/Images/SImage.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SHyperlink.h"
@@ -41,6 +44,7 @@
 
 // Static deduplication map definition
 TMap<FString, TWeakPtr<FSGDynamicTextAssetEditorToolkit>> FSGDynamicTextAssetEditorToolkit::OPEN_EDITORS;
+TMap<FString, FSGDynamicTextAssetEditorToolkit::FDirtyObjectCacheEntry> FSGDynamicTextAssetEditorToolkit::DIRTY_OBJECT_CACHE;
 
 FSGDynamicTextAssetEditorToolkit::FSGDynamicTextAssetEditorToolkit()
 {
@@ -51,6 +55,15 @@ FSGDynamicTextAssetEditorToolkit::~FSGDynamicTextAssetEditorToolkit()
     if (GEditor)
     {
         GEditor->UnregisterForUndo(this);
+    }
+
+    // Cache the dirty object so it survives GC until the editor is reopened or changes are discarded
+    if (!FilePath.IsEmpty() && bHasUnsavedChanges && EditedDynamicTextAssetStrong.IsValid())
+    {
+        DIRTY_OBJECT_CACHE.Add(FilePath, FDirtyObjectCacheEntry{
+            MoveTemp(EditedDynamicTextAssetStrong),
+            LoadedFileFormatVersion
+        });
     }
 
     if (!FilePath.IsEmpty())
@@ -243,8 +256,26 @@ void FSGDynamicTextAssetEditorToolkit::InitEditor(EToolkitMode::Type Mode,
     DetailsView->OnFinishedChangingProperties().AddSP(
         this, &FSGDynamicTextAssetEditorToolkit::OnPropertyChanged);
 
-    // Load data from disk, need to do this first to avoid dependent UI not having any data loaded
-    LoadFromFile();
+    // Check for a cached dirty object from a previously closed editor
+    if (FDirtyObjectCacheEntry* cachedEntry = DIRTY_OBJECT_CACHE.Find(FilePath))
+    {
+        EditedDynamicTextAssetStrong = MoveTemp(cachedEntry->Object);
+        EditedDynamicTextAsset = EditedDynamicTextAssetStrong.Get();
+        LoadedFileFormatVersion = cachedEntry->LoadedFileFormatVersion;
+        DIRTY_OBJECT_CACHE.Remove(FilePath);
+
+        if (DetailsView.IsValid())
+        {
+            DetailsView->SetObject(EditedDynamicTextAsset);
+        }
+
+        bHasUnsavedChanges = true;
+    }
+    else
+    {
+        // Load data from disk, need to do this first to avoid dependent UI not having any data loaded
+        LoadFromFile();
+    }
 
     // Build the default layout: Details area and RawView Stacked
     // Don't forget to increment the version number if its layout is changed due to editor caching!
@@ -395,6 +426,9 @@ void FSGDynamicTextAssetEditorToolkit::ConstructParentClassHyperlink()
 
 bool FSGDynamicTextAssetEditorToolkit::LoadFromFile()
 {
+    // Clear any cached dirty object for this file (Revert should always read from disk)
+    DIRTY_OBJECT_CACHE.Remove(FilePath);
+
     if (FilePath.IsEmpty())
     {
         UE_LOG(LogSGDynamicTextAssetsEditor, Error, TEXT("Cannot load: empty file path"));
@@ -494,7 +528,7 @@ bool FSGDynamicTextAssetEditorToolkit::LoadFromFile()
     return true;
 }
 
-bool FSGDynamicTextAssetEditorToolkit::SaveToFile()
+bool FSGDynamicTextAssetEditorToolkit::SaveToFile(bool bSkipValidation)
 {
     if (!EditedDynamicTextAsset)
     {
@@ -516,58 +550,61 @@ bool FSGDynamicTextAssetEditorToolkit::SaveToFile()
         return false;
     }
 
-    FSGDynamicTextAssetValidationResult validationResult;
-    if (!provider->Native_ValidateDynamicTextAsset(validationResult))
+    if (!bSkipValidation)
     {
-        FString errorMessage = TEXT("Validation failed with the following issues:\n\n");
-        errorMessage += validationResult.ToFormattedString();
-        errorMessage += TEXT("\nPlease fix the error(s) before saving.");
-
-        for (const FSGDynamicTextAssetValidationEntry& error : validationResult.Errors)
+        FSGDynamicTextAssetValidationResult validationResult;
+        if (!provider->Native_ValidateDynamicTextAsset(validationResult))
         {
+            FString errorMessage = TEXT("Validation failed with the following issues:\n\n");
+            errorMessage += validationResult.ToFormattedString();
+            errorMessage += TEXT("\nPlease fix the error(s) before saving.");
+
+            for (const FSGDynamicTextAssetValidationEntry& error : validationResult.Errors)
+            {
+                UE_LOG(LogSGDynamicTextAssetsEditor, Warning,
+                    TEXT("Validation error for '%s' [%s]: %s"),
+                    *provider->GetUserFacingId(),
+                    *error.PropertyPath,
+                    *error.Message.ToString());
+            }
+
             UE_LOG(LogSGDynamicTextAssetsEditor, Warning,
-                TEXT("Validation error for '%s' [%s]: %s"),
+                TEXT("Cannot save '%s' (%s): validation failed with %d issue(s)"),
                 *provider->GetUserFacingId(),
-                *error.PropertyPath,
-                *error.Message.ToString());
-        }
+                *provider->GetDynamicTextAssetId().ToString(),
+                validationResult.GetTotalCount());
 
-        UE_LOG(LogSGDynamicTextAssetsEditor, Warning,
-            TEXT("Cannot save '%s' (%s): validation failed with %d issue(s)"),
-            *provider->GetUserFacingId(),
-            *provider->GetDynamicTextAssetId().ToString(),
-            validationResult.GetTotalCount());
+            FMessageDialog::Open(EAppMsgType::Ok,
+                FText::FromString(errorMessage),
+                INVTEXT("Validation Failed"));
 
-        FMessageDialog::Open(EAppMsgType::Ok,
-            FText::FromString(errorMessage),
-            INVTEXT("Validation Failed"));
-
-        return false;
-    }
-
-    // Show warnings to the user and let them decide whether to proceed
-    if (validationResult.HasWarnings())
-    {
-        for (const FSGDynamicTextAssetValidationEntry& warning : validationResult.Warnings)
-        {
-            UE_LOG(LogSGDynamicTextAssetsEditor, Warning,
-                TEXT("Validation warning for '%s' [%s]: %s"),
-                *provider->GetUserFacingId(),
-                *warning.PropertyPath,
-                *warning.Message.ToString());
-        }
-
-        FString warningMessage = TEXT("Validation produced the following warnings:\n\n");
-        warningMessage += validationResult.ToFormattedString();
-        warningMessage += TEXT("\nDo you want to save anyway?");
-
-        EAppReturnType::Type userChoice = FMessageDialog::Open(EAppMsgType::YesNo,
-            FText::FromString(warningMessage),
-            INVTEXT("Validation Warnings"));
-
-        if (userChoice != EAppReturnType::Yes)
-        {
             return false;
+        }
+
+        // Show warnings to the user and let them decide whether to proceed
+        if (validationResult.HasWarnings())
+        {
+            for (const FSGDynamicTextAssetValidationEntry& warning : validationResult.Warnings)
+            {
+                UE_LOG(LogSGDynamicTextAssetsEditor, Warning,
+                    TEXT("Validation warning for '%s' [%s]: %s"),
+                    *provider->GetUserFacingId(),
+                    *warning.PropertyPath,
+                    *warning.Message.ToString());
+            }
+
+            FString warningMessage = TEXT("Validation produced the following warnings:\n\n");
+            warningMessage += validationResult.ToFormattedString();
+            warningMessage += TEXT("\nDo you want to save anyway?");
+
+            EAppReturnType::Type userChoice = FMessageDialog::Open(EAppMsgType::YesNo,
+                FText::FromString(warningMessage),
+                INVTEXT("Validation Warnings"));
+
+            if (userChoice != EAppReturnType::Yes)
+            {
+                return false;
+            }
         }
     }
 
@@ -633,6 +670,7 @@ bool FSGDynamicTextAssetEditorToolkit::SaveToFile()
     }
 
     MarkClean();
+    DIRTY_OBJECT_CACHE.Remove(FilePath);
     RefreshRawView();
 
     // Incrementally update the project info cache with this file's format version
@@ -650,6 +688,297 @@ bool FSGDynamicTextAssetEditorToolkit::SaveToFile()
 
     UE_LOG(LogSGDynamicTextAssetsEditor, Log, TEXT("Saved dynamic text asset to: %s"), *FilePath);
     return true;
+}
+
+bool FSGDynamicTextAssetEditorToolkit::HandleCanCloseEditor()
+{
+    // Collect all dirty DTAs from open editors and the dirty object cache
+    TSharedRef<SSGDynamicTextAssetSaveDialog> dialog = SNew(SSGDynamicTextAssetSaveDialog);
+    bool bHasAnyDirty = false;
+
+    // From open editors
+    for (const TPair<FString, TWeakPtr<FSGDynamicTextAssetEditorToolkit>>& pair : OPEN_EDITORS)
+    {
+        TSharedPtr<FSGDynamicTextAssetEditorToolkit> toolkit = pair.Value.Pin();
+        if (toolkit.IsValid() && toolkit->HasUnsavedChanges())
+        {
+            FString assetName = TEXT("Unknown");
+            FString typeName = TEXT("Unknown");
+            if (ISGDynamicTextAssetProvider* provider = Cast<ISGDynamicTextAssetProvider>(toolkit->EditedDynamicTextAsset))
+            {
+                assetName = provider->GetUserFacingId();
+            }
+            if (toolkit->EditedDynamicTextAsset)
+            {
+                typeName = toolkit->EditedDynamicTextAsset->GetClass()->GetName();
+            }
+
+            FString relativePath;
+            FString contentDir = FPaths::ProjectContentDir();
+            if (pair.Key.StartsWith(contentDir))
+            {
+                relativePath = pair.Key.RightChop(contentDir.Len());
+            }
+            else
+            {
+                relativePath = FPaths::GetCleanFilename(pair.Key);
+            }
+
+            dialog->AddItem(assetName, relativePath, typeName, pair.Key);
+            bHasAnyDirty = true;
+        }
+    }
+
+    // From dirty object cache (closed editors with unsaved changes)
+    for (const TPair<FString, FDirtyObjectCacheEntry>& pair : DIRTY_OBJECT_CACHE)
+    {
+        FString assetName = TEXT("Unknown");
+        FString typeName = TEXT("Unknown");
+        if (pair.Value.Object.IsValid())
+        {
+            if (ISGDynamicTextAssetProvider* provider = Cast<ISGDynamicTextAssetProvider>(pair.Value.Object.Get()))
+            {
+                assetName = provider->GetUserFacingId();
+            }
+            typeName = pair.Value.Object->GetClass()->GetName();
+        }
+
+        FString relativePath;
+        FString contentDir = FPaths::ProjectContentDir();
+        if (pair.Key.StartsWith(contentDir))
+        {
+            relativePath = pair.Key.RightChop(contentDir.Len());
+        }
+        else
+        {
+            relativePath = FPaths::GetCleanFilename(pair.Key);
+        }
+
+        dialog->AddItem(assetName, relativePath, typeName, pair.Key);
+        bHasAnyDirty = true;
+    }
+
+    // No dirty DTAs, allow close
+    if (!bHasAnyDirty)
+    {
+        return true;
+    }
+
+    // Show modal dialog
+    TSharedRef<SWindow> modalWindow = SNew(SWindow)
+        .Title(INVTEXT("Save Content"))
+        .ClientSize(FVector2D(640, 492))
+        .SupportsMinimize(false)
+        .SupportsMaximize(false);
+
+    modalWindow->SetContent(dialog);
+    dialog->SetParentWindow(modalWindow);
+
+    GEditor->EditorAddModalWindow(modalWindow);
+
+    switch (dialog->GetResult())
+    {
+        case ESGDTASaveDialogResult::SaveSelected:
+        {
+            TArray<TSharedPtr<FSGDTASaveDialogItem>> checkedItems = dialog->GetCheckedItems();
+
+            // Phase 1: Pre-validate all checked items and separate into passed/failed
+            TArray<TSharedPtr<FSGDTASaveDialogItem>> validItems;
+            int32 validationFailCount = 0;
+
+            for (const TSharedPtr<FSGDTASaveDialogItem>& item : checkedItems)
+            {
+                if (!item.IsValid())
+                {
+                    continue;
+                }
+
+                // Find the provider for this item (from open editor or dirty cache)
+                ISGDynamicTextAssetProvider* provider = nullptr;
+
+                TWeakPtr<FSGDynamicTextAssetEditorToolkit>* editorEntry = OPEN_EDITORS.Find(item->AbsoluteFilePath);
+                if (editorEntry)
+                {
+                    TSharedPtr<FSGDynamicTextAssetEditorToolkit> toolkit = editorEntry->Pin();
+                    if (toolkit.IsValid() && toolkit->EditedDynamicTextAsset)
+                    {
+                        provider = Cast<ISGDynamicTextAssetProvider>(toolkit->EditedDynamicTextAsset);
+                    }
+                }
+
+                if (!provider)
+                {
+                    if (FDirtyObjectCacheEntry* cachedEntry = DIRTY_OBJECT_CACHE.Find(item->AbsoluteFilePath))
+                    {
+                        if (cachedEntry->Object.IsValid())
+                        {
+                            provider = Cast<ISGDynamicTextAssetProvider>(cachedEntry->Object.Get());
+                        }
+                    }
+                }
+
+                if (!provider)
+                {
+                    UE_LOG(LogSGDynamicTextAssetsEditor, Warning,
+                        TEXT("Shutdown save: no provider found for %s, skipping"), *item->AbsoluteFilePath);
+                    continue;
+                }
+
+                FSGDynamicTextAssetValidationResult validationResult;
+                if (provider->Native_ValidateDynamicTextAsset(validationResult))
+                {
+                    validItems.Add(item);
+                }
+                else
+                {
+                    validationFailCount++;
+                    UE_LOG(LogSGDynamicTextAssetsEditor, Warning,
+                        TEXT("Shutdown save: validation failed for '%s' (%s) with %d issue(s)"),
+                        *provider->GetUserFacingId(),
+                        *item->AbsoluteFilePath,
+                        validationResult.GetTotalCount());
+
+                    for (const FSGDynamicTextAssetValidationEntry& error : validationResult.Errors)
+                    {
+                        UE_LOG(LogSGDynamicTextAssetsEditor, Warning,
+                            TEXT("  Validation error [%s]: %s"),
+                            *error.PropertyPath,
+                            *error.Message.ToString());
+                    }
+                }
+            }
+
+            // Phase 2: Save all items that passed validation (skip re-validation)
+            int32 writeFailCount = 0;
+
+            for (const TSharedPtr<FSGDTASaveDialogItem>& item : validItems)
+            {
+                bool bSaved = false;
+
+                // Try saving via open editor first
+                if (TWeakPtr<FSGDynamicTextAssetEditorToolkit>* editorEntry = OPEN_EDITORS.Find(item->AbsoluteFilePath))
+                {
+                    TSharedPtr<FSGDynamicTextAssetEditorToolkit> toolkit = editorEntry->Pin();
+                    if (toolkit.IsValid() && toolkit->HasUnsavedChanges())
+                    {
+                        bSaved = toolkit->SaveToFile(true);
+                        if (!bSaved)
+                        {
+                            writeFailCount++;
+                            UE_LOG(LogSGDynamicTextAssetsEditor, Warning,
+                                TEXT("Shutdown save: failed to save open editor for %s"), *item->AbsoluteFilePath);
+                        }
+                        continue;
+                    }
+                }
+
+                // Save cached dirty objects that have no open editor
+                if (FDirtyObjectCacheEntry* cachedEntry = DIRTY_OBJECT_CACHE.Find(item->AbsoluteFilePath))
+                {
+                    if (cachedEntry->Object.IsValid())
+                    {
+                        if (ISGDynamicTextAssetProvider* provider = Cast<ISGDynamicTextAssetProvider>(cachedEntry->Object.Get()))
+                        {
+                            TSharedPtr<ISGDynamicTextAssetSerializer> serializer =
+                                FSGDynamicTextAssetFileManager::FindSerializerForFile(item->AbsoluteFilePath);
+                            if (serializer.IsValid())
+                            {
+                                FString serializedContents;
+                                if (serializer->SerializeProvider(provider, serializedContents)
+                                    && FSGDynamicTextAssetFileManager::WriteRawFileContents(item->AbsoluteFilePath, serializedContents))
+                                {
+                                    bSaved = true;
+                                }
+                            }
+                        }
+                    }
+
+                    if (!bSaved)
+                    {
+                        writeFailCount++;
+                        UE_LOG(LogSGDynamicTextAssetsEditor, Warning,
+                            TEXT("Shutdown save: failed to write cached DTA %s"), *item->AbsoluteFilePath);
+                    }
+                }
+            }
+
+            // Phase 3: Handle validation failures
+            if (validationFailCount > 0)
+            {
+                FString message = FString::Printf(
+                    TEXT("%d asset(s) failed validation and could not be saved.\n"
+                         "Refer to the log or re-run validation for details.\n\n"
+                         "Assets that passed validation have been saved.\n\n"
+                         "Discard changes to the failed asset(s) and close the editor?"),
+                    validationFailCount);
+
+                EAppReturnType::Type choice = FMessageDialog::Open(EAppMsgType::YesNo,
+                    FText::FromString(message),
+                    INVTEXT("Validation Failed"));
+
+                if (choice != EAppReturnType::Yes)
+                {
+                    // User chose Don't Discard - cancel shutdown so they can fix validation
+                    return false;
+                }
+            }
+
+            // Phase 4: Handle write failures
+            if (writeFailCount > 0)
+            {
+                FString message = FString::Printf(
+                    TEXT("%d file(s) failed to save properly.\n"
+                         "Please refer to logs for information on the failure reason.\n\n"
+                         "Continue closing editor?"),
+                    writeFailCount);
+
+                EAppReturnType::Type choice = FMessageDialog::Open(EAppMsgType::YesNo,
+                    FText::FromString(message),
+                    INVTEXT("Save Failed"));
+
+                if (choice != EAppReturnType::Yes)
+                {
+                    return false;
+                }
+            }
+
+            // Clear all cached dirty objects (saved or intentionally discarded)
+            DIRTY_OBJECT_CACHE.Empty();
+
+            // Mark all open dirty editors clean so they close without re-caching in the destructor
+            for (const TPair<FString, TWeakPtr<FSGDynamicTextAssetEditorToolkit>>& pair : OPEN_EDITORS)
+            {
+                TSharedPtr<FSGDynamicTextAssetEditorToolkit> toolkit = pair.Value.Pin();
+                if (toolkit.IsValid() && toolkit->HasUnsavedChanges())
+                {
+                    toolkit->MarkClean();
+                }
+            }
+
+            return true;
+        }
+        case ESGDTASaveDialogResult::DontSave:
+        {
+            // Discard all unsaved changes
+            DIRTY_OBJECT_CACHE.Empty();
+
+            for (const TPair<FString, TWeakPtr<FSGDynamicTextAssetEditorToolkit>>& pair : OPEN_EDITORS)
+            {
+                TSharedPtr<FSGDynamicTextAssetEditorToolkit> toolkit = pair.Value.Pin();
+                if (toolkit.IsValid() && toolkit->HasUnsavedChanges())
+                {
+                    toolkit->MarkClean();
+                }
+            }
+
+            return true;
+        }
+        // ESGDTASaveDialogResult::Cancelled
+        default:
+        {
+            return false;
+        }
+    }
 }
 
 bool FSGDynamicTextAssetEditorToolkit::CanSaveAsset() const
@@ -835,6 +1164,12 @@ void FSGDynamicTextAssetEditorToolkit::NotifyFileRenamed(const FString& OldFileP
     toolkit->FilePath = NewFilePath;
     OPEN_EDITORS.Add(NewFilePath, toolkit);
 
+    // Update dirty object cache key if it exists
+    if (FDirtyObjectCacheEntry cachedEntry; DIRTY_OBJECT_CACHE.RemoveAndCopyValue(OldFilePath, cachedEntry))
+    {
+        DIRTY_OBJECT_CACHE.Add(NewFilePath, MoveTemp(cachedEntry));
+    }
+
     // Reload UserFacingId from the renamed file's file info
     if (ISGDynamicTextAssetProvider* provider = Cast<ISGDynamicTextAssetProvider>(toolkit->EditedDynamicTextAsset))
     {
@@ -867,6 +1202,7 @@ void FSGDynamicTextAssetEditorToolkit::NotifyFileDeleted(const FString& InFilePa
 
     // Remove before CloseWindow so the destructor's OPEN_EDITORS.Remove is a harmless no-op
     OPEN_EDITORS.Remove(InFilePath);
+    DIRTY_OBJECT_CACHE.Remove(InFilePath);
     toolkit->CloseWindow(EAssetEditorCloseReason::AssetUnloadingOrInvalid);
 
     UE_LOG(LogSGDynamicTextAssetsEditor, Log, TEXT("NotifyFileDeleted: closed editor for %s"), *InFilePath);
@@ -875,18 +1211,17 @@ void FSGDynamicTextAssetEditorToolkit::NotifyFileDeleted(const FString& InFilePa
 bool FSGDynamicTextAssetEditorToolkit::HasOpenEditorWithUnsavedChanges(const FString& InFilePath)
 {
     TWeakPtr<FSGDynamicTextAssetEditorToolkit>* existing = OPEN_EDITORS.Find(InFilePath);
-    if (!existing || !existing->IsValid())
+    if (existing && existing->IsValid())
     {
-        return false;
+        TSharedPtr<FSGDynamicTextAssetEditorToolkit> toolkit = existing->Pin();
+        if (toolkit.IsValid())
+        {
+            return toolkit->HasUnsavedChanges();
+        }
     }
 
-    TSharedPtr<FSGDynamicTextAssetEditorToolkit> toolkit = existing->Pin();
-    if (!toolkit.IsValid())
-    {
-        return false;
-    }
-
-    return toolkit->HasUnsavedChanges();
+    // Also check the dirty object cache for closed-but-dirty editors
+    return DIRTY_OBJECT_CACHE.Contains(InFilePath);
 }
 
 bool FSGDynamicTextAssetEditorToolkit::SaveOpenEditor(const FString& InFilePath)

--- a/Source/SGDynamicTextAssetsEditor/Private/Editor/SSGDynamicTextAssetSaveDialog.cpp
+++ b/Source/SGDynamicTextAssetsEditor/Private/Editor/SSGDynamicTextAssetSaveDialog.cpp
@@ -1,0 +1,326 @@
+// Copyright Start Games, Inc. All Rights Reserved.
+
+#include "Editor/SSGDynamicTextAssetSaveDialog.h"
+
+#include "Framework/Application/SlateApplication.h"
+#include "SGDynamicTextAssetEditorLogs.h"
+#include "Styling/AppStyle.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Text/STextBlock.h"
+
+namespace SGDTASaveDialogColumns
+{
+    static const FName CheckBox("CheckBox");
+    static const FName Asset("Asset");
+    static const FName File("File");
+    static const FName Type("Type");
+}
+
+void SSGDynamicTextAssetSaveDialog::Construct(const FArguments& InArgs)
+{
+    TSharedRef<SHeaderRow> headerRow = SNew(SHeaderRow)
+
+        + SHeaderRow::Column(SGDTASaveDialogColumns::CheckBox)
+        [
+            SNew(SBox)
+            .Padding(FMargin(6, 3, 6, 3))
+            .HAlign(HAlign_Center)
+            [
+                SNew(SCheckBox)
+                .IsChecked(this, &SSGDynamicTextAssetSaveDialog::GetHeaderCheckState)
+                .OnCheckStateChanged(this, &SSGDynamicTextAssetSaveDialog::OnHeaderCheckStateChanged)
+            ]
+        ]
+        .FixedWidth(38.0f)
+
+        + SHeaderRow::Column(SGDTASaveDialogColumns::Asset)
+        .DefaultLabel(INVTEXT("Asset"))
+        .FillWidth(5.0f)
+
+        + SHeaderRow::Column(SGDTASaveDialogColumns::File)
+        .DefaultLabel(INVTEXT("File"))
+        .FillWidth(7.0f)
+
+        + SHeaderRow::Column(SGDTASaveDialogColumns::Type)
+        .DefaultLabel(INVTEXT("Type"))
+        .FillWidth(2.0f);
+
+    ChildSlot
+    [
+        SNew(SBorder)
+        .BorderImage(FAppStyle::GetBrush("Brushes.Panel"))
+        .Padding(FMargin(16))
+        [
+            SNew(SVerticalBox)
+
+            // Header message
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 8.0f)
+            [
+                SNew(STextBlock)
+                .Text(INVTEXT("Select Content to Save"))
+                .AutoWrapText(true)
+            ]
+
+            // Item list
+            + SVerticalBox::Slot()
+            .FillHeight(0.8f)
+            [
+                SAssignNew(ItemListView, SListView<TSharedPtr<FSGDTASaveDialogItem>>)
+                .ListItemsSource(&Items)
+                .OnGenerateRow(this, &SSGDynamicTextAssetSaveDialog::GenerateRow)
+                .SelectionMode(ESelectionMode::None)
+                .HeaderRow(headerRow)
+            ]
+
+            // Button bar
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 16.0f, 0.0f, 0.0f)
+            .HAlign(HAlign_Right)
+            .VAlign(VAlign_Bottom)
+            [
+                SNew(SHorizontalBox)
+
+                + SHorizontalBox::Slot()
+                .AutoWidth()
+                .Padding(5, 0)
+                [
+                    SNew(SButton)
+                    .ButtonStyle(&FAppStyle::Get(), "PrimaryButton")
+                    .TextStyle(&FAppStyle::Get(), "PrimaryButtonText")
+                    .Text(INVTEXT("Save Selected"))
+                    .ToolTipText(INVTEXT("Save the selected dynamic text assets"))
+                    .OnClicked_Lambda([this]() { OnSaveSelectedClicked(); return FReply::Handled(); })
+                ]
+
+                + SHorizontalBox::Slot()
+                .AutoWidth()
+                .Padding(5, 0)
+                [
+                    SNew(SButton)
+                    .ButtonStyle(&FAppStyle::Get(), "Button")
+                    .TextStyle(&FAppStyle::Get(), "ButtonText")
+                    .Text(INVTEXT("Don't Save"))
+                    .ToolTipText(INVTEXT("Discard all unsaved dynamic text asset changes"))
+                    .OnClicked_Lambda([this]() { OnDontSaveClicked(); return FReply::Handled(); })
+                ]
+
+                + SHorizontalBox::Slot()
+                .AutoWidth()
+                .Padding(5, 0)
+                [
+                    SNew(SButton)
+                    .ButtonStyle(&FAppStyle::Get(), "Button")
+                    .TextStyle(&FAppStyle::Get(), "ButtonText")
+                    .Text(INVTEXT("Cancel"))
+                    .ToolTipText(INVTEXT("Cancel the close operation"))
+                    .OnClicked_Lambda([this]() { OnCancelClicked(); return FReply::Handled(); })
+                ]
+            ]
+        ]
+    ];
+}
+
+void SSGDynamicTextAssetSaveDialog::AddItem(const FString& InAssetName, const FString& InFilePath,
+    const FString& InTypeName, const FString& InAbsoluteFilePath)
+{
+    TSharedPtr<FSGDTASaveDialogItem> item = MakeShared<FSGDTASaveDialogItem>();
+    item->AssetName = InAssetName;
+    item->FilePath = InFilePath;
+    item->TypeName = InTypeName;
+    item->AbsoluteFilePath = InAbsoluteFilePath;
+    item->CheckState = ECheckBoxState::Checked;
+    Items.Add(item);
+
+    if (ItemListView.IsValid())
+    {
+        ItemListView->RequestListRefresh();
+    }
+}
+
+
+TArray<TSharedPtr<FSGDTASaveDialogItem>> SSGDynamicTextAssetSaveDialog::GetCheckedItems() const
+{
+    TArray<TSharedPtr<FSGDTASaveDialogItem>> checkedItems;
+    for (const TSharedPtr<FSGDTASaveDialogItem>& item : Items)
+    {
+        if (item.IsValid() && item->CheckState == ECheckBoxState::Checked)
+        {
+            checkedItems.Add(item);
+        }
+    }
+    return checkedItems;
+}
+
+TSharedRef<ITableRow> SSGDynamicTextAssetSaveDialog::GenerateRow(
+    TSharedPtr<FSGDTASaveDialogItem> Item,
+    const TSharedRef<STableViewBase>& OwnerTable)
+{
+    return SNew(SSGDTASaveDialogRow, OwnerTable)
+        .Item(Item)
+        .Dialog(SharedThis(this));
+}
+
+ECheckBoxState SSGDynamicTextAssetSaveDialog::GetHeaderCheckState() const
+{
+    if (Items.Num() == 0)
+    {
+        return ECheckBoxState::Unchecked;
+    }
+
+    int32 checkedCount = 0;
+    for (const TSharedPtr<FSGDTASaveDialogItem>& item : Items)
+    {
+        if (item.IsValid() && item->CheckState == ECheckBoxState::Checked)
+        {
+            ++checkedCount;
+        }
+    }
+
+    if (checkedCount == 0)
+    {
+        return ECheckBoxState::Unchecked;
+    }
+    if (checkedCount == Items.Num())
+    {
+        return ECheckBoxState::Checked;
+    }
+    return ECheckBoxState::Undetermined;
+}
+
+void SSGDynamicTextAssetSaveDialog::OnHeaderCheckStateChanged(ECheckBoxState NewState)
+{
+    ECheckBoxState targetState = (NewState == ECheckBoxState::Checked)
+        ? ECheckBoxState::Checked
+        : ECheckBoxState::Unchecked;
+
+    for (const TSharedPtr<FSGDTASaveDialogItem>& item : Items)
+    {
+        if (item.IsValid())
+        {
+            item->CheckState = targetState;
+        }
+    }
+
+    if (ItemListView.IsValid())
+    {
+        ItemListView->RequestListRefresh();
+    }
+}
+
+void SSGDynamicTextAssetSaveDialog::OnSaveSelectedClicked()
+{
+    Result = ESGDTASaveDialogResult::SaveSelected;
+    CloseDialog();
+}
+
+void SSGDynamicTextAssetSaveDialog::OnDontSaveClicked()
+{
+    Result = ESGDTASaveDialogResult::DontSave;
+    CloseDialog();
+}
+
+void SSGDynamicTextAssetSaveDialog::OnCancelClicked()
+{
+    Result = ESGDTASaveDialogResult::Cancelled;
+    CloseDialog();
+}
+
+void SSGDynamicTextAssetSaveDialog::CloseDialog()
+{
+    if (TSharedPtr<SWindow> window = ParentWindow.Pin())
+    {
+        window->RequestDestroyWindow();
+    }
+}
+
+FReply SSGDynamicTextAssetSaveDialog::OnKeyDown(const FGeometry& MyGeometry, const FKeyEvent& InKeyEvent)
+{
+    if (InKeyEvent.GetKey() == EKeys::Escape)
+    {
+        OnCancelClicked();
+        return FReply::Handled();
+    }
+    return SCompoundWidget::OnKeyDown(MyGeometry, InKeyEvent);
+}
+
+void SSGDTASaveDialogRow::Construct(const FArguments& InArgs,
+    const TSharedRef<STableViewBase>& InOwnerTable)
+{
+    Item = InArgs._Item;
+    Dialog = InArgs._Dialog;
+
+    SMultiColumnTableRow<TSharedPtr<FSGDTASaveDialogItem>>::Construct(
+        SMultiColumnTableRow<TSharedPtr<FSGDTASaveDialogItem>>::FArguments(),
+        InOwnerTable);
+}
+
+TSharedRef<SWidget> SSGDTASaveDialogRow::GenerateWidgetForColumn(const FName& ColumnName)
+{
+    static const FMargin rowPadding(3, 3, 3, 3);
+
+    if (!Item.IsValid())
+    {
+        return SNullWidget::NullWidget;
+    }
+
+    if (ColumnName == SGDTASaveDialogColumns::CheckBox)
+    {
+        return SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+            .Padding(FMargin(10, 3, 6, 3))
+            [
+                SNew(SCheckBox)
+                .IsChecked_Lambda([this]() { return Item->CheckState; })
+                .OnCheckStateChanged_Lambda([this](ECheckBoxState NewState)
+                {
+                    Item->CheckState = NewState;
+                    if (TSharedPtr<SSGDynamicTextAssetSaveDialog> dialogPinned = Dialog.Pin())
+                    {
+                        // Force header checkbox to re-evaluate tri-state
+                    }
+                })
+            ];
+    }
+
+    if (ColumnName == SGDTASaveDialogColumns::Asset)
+    {
+        return SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+            .Padding(rowPadding)
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(Item->AssetName))
+            ];
+    }
+
+    if (ColumnName == SGDTASaveDialogColumns::File)
+    {
+        return SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+            .Padding(rowPadding)
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(Item->FilePath))
+                .ToolTipText(FText::FromString(Item->AbsoluteFilePath))
+            ];
+    }
+
+    if (ColumnName == SGDTASaveDialogColumns::Type)
+    {
+        return SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+            .Padding(rowPadding)
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(Item->TypeName))
+            ];
+    }
+
+    return SNullWidget::NullWidget;
+}

--- a/Source/SGDynamicTextAssetsEditor/Private/SGDynamicTextAssetsEditorModule.cpp
+++ b/Source/SGDynamicTextAssetsEditor/Private/SGDynamicTextAssetsEditorModule.cpp
@@ -35,6 +35,7 @@
 #include "Management/SGDynamicTextAssetFileManager.h"
 #include "Framework/Notifications/NotificationManager.h"
 #include "Widgets/Notifications/SNotificationList.h"
+#include "Interfaces/IMainFrameModule.h"
 
 #define LOCTEXT_NAMESPACE "FSGDynamicTextAssetsEditorModule"
 
@@ -127,12 +128,28 @@ public:
                 });
             }
         });
+
+        // Register shutdown hook so unsaved DTA changes prompt a save dialog before the editor closes
+        if (FModuleManager::Get().IsModuleLoaded("MainFrame"))
+        {
+            IMainFrameModule& mainFrameModule = FModuleManager::LoadModuleChecked<IMainFrameModule>("MainFrame");
+            CanCloseEditorDelegateHandle = mainFrameModule.RegisterCanCloseEditor(
+                IMainFrameModule::FMainFrameCanCloseEditor::CreateStatic(&FSGDynamicTextAssetEditorToolkit::HandleCanCloseEditor));
+        }
     }
 
     /** Called when the module is unloaded from memory. */
     virtual void ShutdownModule() override
     {
         UE_LOG(LogSGDynamicTextAssetsEditor, Log, TEXT("SGDynamicTextAssetsEditor module shutdown"));
+
+        // Unregister shutdown save dialog hook
+        if (CanCloseEditorDelegateHandle.IsValid() && FModuleManager::Get().IsModuleLoaded("MainFrame"))
+        {
+            IMainFrameModule& mainFrameModule = FModuleManager::LoadModuleChecked<IMainFrameModule>("MainFrame");
+            mainFrameModule.UnregisterCanCloseEditor(CanCloseEditorDelegateHandle);
+            CanCloseEditorDelegateHandle.Reset();
+        }
 
         // Unsubscribe from cook delegates
         UE::Cook::FDelegates::CookStarted.Remove(CookStartedHandle);
@@ -648,6 +665,9 @@ private:
 
     /** Handle for the ModifyCook delegate subscription (soft reference cook inclusion) */
     FDelegateHandle ModifyCookHandle;
+
+    /** Handle for the CanCloseEditor delegate (DTA shutdown save dialog) */
+    FDelegateHandle CanCloseEditorDelegateHandle;
 };
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/SGDynamicTextAssetsEditor/Public/Editor/SGDynamicTextAssetEditorToolkit.h
+++ b/Source/SGDynamicTextAssetsEditor/Public/Editor/SGDynamicTextAssetEditorToolkit.h
@@ -135,6 +135,13 @@ public:
      */
     static bool SaveOpenEditor(const FString& FilePath);
 
+    /**
+     * Registered with IMainFrameModule::RegisterCanCloseEditor to intercept editor shutdown.
+     * Collects all dirty DTAs (open editors + cached dirty objects), shows a modal save dialog,
+     * and returns false to block shutdown if the user cancels.
+     */
+    static bool HandleCanCloseEditor();
+
     /** Returns the absolute path of the file being edited. */
     const FString& GetFilePath() const { return FilePath; }
 
@@ -163,7 +170,13 @@ private:
     /** Loads the dynamic text asset from FilePath into EditedDynamicTextAsset. */
     bool LoadFromFile();
 
-    bool SaveToFile();
+    /**
+     * Saves the in-memory dynamic text asset to its JSON file on disk.
+     *
+     * @param bSkipValidation  If true, bypasses validation and warning dialogs.
+     *                         Used during shutdown saves where validation is handled externally.
+     */
+    bool SaveToFile(bool bSkipValidation = false);
 
     void MarkDirty();
     void MarkClean();
@@ -211,4 +224,14 @@ private:
 
     /** Weak references to all currently open toolkits, keyed by file path. */
     static TMap<FString, TWeakPtr<FSGDynamicTextAssetEditorToolkit>> OPEN_EDITORS;
+
+    /** Entry for caching a dirty UObject when an editor tab is closed with unsaved changes. */
+    struct FDirtyObjectCacheEntry
+    {
+        TStrongObjectPtr<UObject> Object;
+        FSGDynamicTextAssetVersion LoadedFileFormatVersion;
+    };
+
+    /** Cached dirty objects for editors that were closed with unsaved changes. Keyed by file path. */
+    static TMap<FString, FDirtyObjectCacheEntry> DIRTY_OBJECT_CACHE;
 };

--- a/Source/SGDynamicTextAssetsEditor/Public/Editor/SSGDynamicTextAssetSaveDialog.h
+++ b/Source/SGDynamicTextAssetsEditor/Public/Editor/SSGDynamicTextAssetSaveDialog.h
@@ -1,0 +1,115 @@
+// Copyright Start Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/Views/SListView.h"
+#include "Widgets/Views/SHeaderRow.h"
+
+/**
+ * Result of the DTA save dialog.
+ */
+enum class ESGDTASaveDialogResult : uint8
+{
+    SaveSelected,
+    DontSave,
+    Cancelled
+};
+
+/**
+ * A single item in the DTA save dialog list.
+ */
+struct FSGDTASaveDialogItem
+{
+    /** Human-readable asset name (UserFacingId) */
+    FString AssetName;
+
+    /** Relative file path from Content/ */
+    FString FilePath;
+
+    /** Class name of the DTA type */
+    FString TypeName;
+
+    /** Absolute file path for save operations */
+    FString AbsoluteFilePath;
+
+    /** Whether this item is checked for saving */
+    ECheckBoxState CheckState = ECheckBoxState::Checked;
+};
+
+/**
+ * Modal save dialog for unsaved DTA changes, mimicking the UE "Save Content" dialog.
+ *
+ * Shows a checkbox list of dirty DTA files with Asset, File, and Type columns,
+ * and Save Selected / Don't Save / Cancel buttons.
+ */
+class SGDYNAMICTEXTASSETSEDITOR_API SSGDynamicTextAssetSaveDialog : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSGDynamicTextAssetSaveDialog) {}
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs);
+
+    /** Adds a dirty DTA item to the list. Call before showing the dialog. */
+    void AddItem(const FString& InAssetName, const FString& InFilePath,
+                 const FString& InTypeName, const FString& InAbsoluteFilePath);
+
+    /** Returns the result chosen by the user. */
+    ESGDTASaveDialogResult GetResult() const { return Result; }
+
+    /** Returns all items that were checked when the user clicked Save Selected. */
+    TArray<TSharedPtr<FSGDTASaveDialogItem>> GetCheckedItems() const;
+
+    /** Sets the parent window reference so the dialog can close itself. */
+    void SetParentWindow(TSharedPtr<SWindow> InWindow) { ParentWindow = InWindow; }
+
+private:
+
+    TSharedRef<ITableRow> GenerateRow(TSharedPtr<FSGDTASaveDialogItem> Item,
+                                      const TSharedRef<STableViewBase>& OwnerTable);
+
+    /** Returns the tri-state of the header checkbox based on all items. */
+    ECheckBoxState GetHeaderCheckState() const;
+
+    /** Toggles all item checkboxes. */
+    void OnHeaderCheckStateChanged(ECheckBoxState NewState);
+
+    void OnSaveSelectedClicked();
+    void OnDontSaveClicked();
+    void OnCancelClicked();
+
+    /** Closes the parent modal window. */
+    void CloseDialog();
+
+    virtual FReply OnKeyDown(const FGeometry& MyGeometry, const FKeyEvent& InKeyEvent) override;
+
+    TArray<TSharedPtr<FSGDTASaveDialogItem>> Items;
+    TSharedPtr<SListView<TSharedPtr<FSGDTASaveDialogItem>>> ItemListView;
+    ESGDTASaveDialogResult Result = ESGDTASaveDialogResult::Cancelled;
+
+    /** Weak reference to the parent modal window for closing. */
+    TWeakPtr<SWindow> ParentWindow;
+};
+
+/**
+ * Multi-column row widget for SSGDynamicTextAssetSaveDialog.
+ */
+class SSGDTASaveDialogRow : public SMultiColumnTableRow<TSharedPtr<FSGDTASaveDialogItem>>
+{
+public:
+    SLATE_BEGIN_ARGS(SSGDTASaveDialogRow) {}
+        SLATE_ARGUMENT(TSharedPtr<FSGDTASaveDialogItem>, Item)
+        SLATE_ARGUMENT(TWeakPtr<SSGDynamicTextAssetSaveDialog>, Dialog)
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs,
+                   const TSharedRef<STableViewBase>& InOwnerTable);
+
+    virtual TSharedRef<SWidget> GenerateWidgetForColumn(const FName& ColumnName) override;
+
+private:
+    TSharedPtr<FSGDTASaveDialogItem> Item;
+    TWeakPtr<SSGDynamicTextAssetSaveDialog> Dialog;
+};

--- a/Source/SGDynamicTextAssetsEditor/SGDynamicTextAssetsEditor.Build.cs
+++ b/Source/SGDynamicTextAssetsEditor/SGDynamicTextAssetsEditor.Build.cs
@@ -36,7 +36,8 @@ public class SGDynamicTextAssetsEditor : ModuleRules
             "LevelEditor",
             "WorkspaceMenuStructure",
             "ToolWidgets",
-            "ClassViewer"
+            "ClassViewer",
+            "MainFrame"
         });
     }
 }


### PR DESCRIPTION
## Bug Description
When closing a DTA's editor that has unsaved modifications, it doesn't keep those unsaved modifications when the DTA is reopened. It should only discard them when the editor is closed.

## Root Cause
DTA's were not being kept in memory when the DTA editor was closed. 

## Proposed Solution
Changing this to be statically saved in the editor fixes the issue.

## Misc Changes
- Added a dialog when closing the UE editor with unsaved changes to have parity with unsaved UE assets approach.
- Added asset dirty icon for DTA browser.

## Related Issue
- [Closing a DTA that has unsaved changes doesn't keep those changes when reopened](https://github.com/Start-Games-Open-Source/SGDynamicTextAssets/issues/11)

## What Was Tested
<!-- Describe how you verified your changes work correctly.
     Example: "Ran all 19 unit tests via Session Frontend > Automation.
     Manually tested cooking a .dta.xml file and loading it at runtime.
     Tested in UE 5.6 on Windows 11." -->
Editor only features, tested in the editor with making changes locally kept when DTA editor is closed.
Also added new feature of save dialog when closing editor to have parity with normal UE asset saving when the editor closes.

## Licensing
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) and confirm that my contribution is submitted under the project's [Elastic License 2.0](./LICENSE).
